### PR TITLE
Update to use modern CMake

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2017
+  
 install:
   - git submodule update --init
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="http://www.cmake.org/files/v3.3/cmake-3.3.2-Linux-x86_64.tar.gz"
+      CMAKE_URL="http://www.cmake.org/files/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60;
@@ -42,8 +42,9 @@ install:
       sudo update-alternatives --config gcc;
       sudo update-alternatives --config g++;
     elif [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      which cmake || brew install cmake
+      which cmake || brew install cmake || brew upgrade cmake
     fi
+  - cmake --version
   - cd ${TRAVIS_BUILD_DIR}
 
 before_script: export CXX=${COMPILER}

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
   - mkdir ${DEPS_DIR} && cd ${DEPS_DIR}
   - |
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      CMAKE_URL="http://www.cmake.org/files/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz"
+      CMAKE_URL="https://github.com/Kitware/CMake/releases/download/v3.15.4/cmake-3.15.4-Linux-x86_64.tar.gz"
       mkdir cmake && travis_retry wget --no-check-certificate --quiet -O - ${CMAKE_URL} | tar --strip-components=1 -xz -C cmake
       export PATH=${DEPS_DIR}/cmake/bin:${PATH}
       sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,7 +46,7 @@ if (${PROPAGATE_CONST_IS_NOT_SUBPROJECT})
     target_compile_options(test_propagate_const
         PRIVATE
             $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
-            $<$<CXX_COMPILER_ID:MSVC>:W4>
+            $<$<CXX_COMPILER_ID:MSVC>:/W4>
             $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
     )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,25 +1,145 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.14)
 
-project(propagate_const)
-
-if(MSVC)
-  add_compile_options("/EHsc")
-else()
-  add_compile_options("-std=gnu++14")
-  set(CMAKE_CXX_FLAGS_SANITIZE "-fsanitize=address,undefined")
-  set(CMAKE_EXE_LINKER_FLAGS_SANITIZE "-fsanitize=address,undefined")
+if(NOT DEFINED PROJECT_NAME)
+    set(PROPAGATE_CONST_IS_NOT_SUBPROJECT ON)
 endif()
 
-if(${CMAKE_CXX_COMPILER_ID} MATCHES "Clang" OR ${CMAKE_CXX_COMPILER_ID} MATCHES "GNU")
-  add_compile_options("-Werror;-Wall")
+set(PROPAGATE_CONST_VALUE_VERSION "1.0.0")
+
+project(propagate_const VERSION ${PROPAGATE_CONST_VALUE_VERSION})
+
+option(ENABLE_SANITIZERS "Enable Address Sanitizer and Undefined Behaviour Sanitizer if available" OFF)
+
+add_library(propagate_const INTERFACE)
+target_include_directories(propagate_const
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include>
+)
+
+target_sources(propagate_const
+    INTERFACE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/propagate_const.h>
+        $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/include/propagate_const.h>
+)
+
+target_compile_features(propagate_const
+    INTERFACE
+        cxx_defaulted_functions
+        cxx_explicit_conversions
+        cxx_noexcept
+        cxx_nullptr
+        cxx_right_angle_brackets
+        cxx_rvalue_references
+)
+
+add_library(propagate_const::propagate_const ALIAS propagate_const)
+
+if (${PROPAGATE_CONST_IS_NOT_SUBPROJECT})
+
+    add_executable(test_propagate_const test_propagate_const.cpp)
+    target_link_libraries(test_propagate_const
+        PRIVATE
+            propagate_const::propagate_const
+    )
+
+    target_compile_options(test_propagate_const
+        PRIVATE
+            $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+            $<$<CXX_COMPILER_ID:MSVC>:W4>
+            $<$<OR:$<CXX_COMPILER_ID:GNU>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:Clang>>:-Werror;-Wall;-Wno-self-assign-overloaded;-Wno-unknown-warning-option>
+    )
+
+    set_target_properties(test_propagate_const PROPERTIES
+        CXX_STANDARD 14
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+    )
+
+    if (ENABLE_SANITIZERS)
+        set(SANITIZER_FLAGS_ASAN "-fsanitize=address -fno-omit-frame-pointer")
+        set(SANITIZER_FLAGS_UBSAN "-fsanitize=undefined")
+
+        include(CheckCXXCompilerFlag)
+        check_cxx_compiler_flag("${SANITIZER_FLAGS_ASAN}" COMPILER_SUPPORTS_ASAN)
+        check_cxx_compiler_flag("${SANITIZER_FLAGS_UBSAN}" COMPILER_SUPPORTS_UBSAN)
+
+        if (COMPILER_SUPPORTS_ASAN)
+            add_library(asan INTERFACE IMPORTED)
+            set_target_properties(asan PROPERTIES
+                INTERFACE_COMPILE_OPTIONS "${SANITIZER_FLAGS_ASAN}"
+                INTERFACE_LINK_OPTIONS "${SANITIZER_FLAGS_ASAN}"
+            )
+            target_link_libraries(test_propagate_const
+                PRIVATE
+                     asan
+            )
+        endif(COMPILER_SUPPORTS_ASAN)
+
+        if (COMPILER_SUPPORTS_UBSAN)
+            add_library(ubsan INTERFACE IMPORTED)
+            set_target_properties(ubsan PROPERTIES
+                INTERFACE_COMPILE_OPTIONS "${SANITIZER_FLAGS_UBSAN}"
+                INTERFACE_LINK_OPTIONS "${SANITIZER_FLAGS_UBSAN}"
+            )
+            target_link_libraries(test_propagate_const
+                PRIVATE
+                     ubsan
+            )
+        endif(COMPILER_SUPPORTS_UBSAN)
+    endif(ENABLE_SANITIZERS)
+
+    enable_testing()
+    add_test(
+        NAME test_propagate_const
+        COMMAND test_propagate_const
+        WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+
+    install(
+        FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/propagate_const.h"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/include
+    )
+
+    install(
+        FILES
+            "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.txt"
+        DESTINATION ${CMAKE_INSTALL_PREFIX}
+    )
+
+    install(
+        TARGETS propagate_const
+        EXPORT propagate_const_target
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake
+    )
+
+    install(
+        EXPORT propagate_const_target
+        NAMESPACE propagate_const::
+        DESTINATION ${CMAKE_INSTALL_PREFIX}/cmake
+	    FILE propagate_const-target.cmake
+    )
+
+    include(CMakePackageConfigHelpers)
+    configure_package_config_file(
+        ${CMAKE_CURRENT_LIST_DIR}/propagate_const-config.cmake.in
+        ${CMAKE_CURRENT_BINARY_DIR}/propagate_const-config.cmake
+        INSTALL_DESTINATION
+            ${CMAKE_INSTALL_PREFIX}/cmake
+    )
+
+    write_basic_package_version_file(
+        ${CMAKE_CURRENT_BINARY_DIR}/propagate_const-version.cmake
+        VERSION ${PROPAGATE_CONST_VERSION}
+        COMPATIBILITY SameMajorVersion
+        ARCH_INDEPENDENT
+    )
+
+    install(
+        FILES
+            ${CMAKE_CURRENT_BINARY_DIR}/propagate_const-config.cmake
+            ${CMAKE_CURRENT_BINARY_DIR}/propagate_const-version.cmake
+        DESTINATION
+            ${CMAKE_INSTALL_PREFIX}/cmake
+    )
 endif()
-
-include_directories(${CMAKE_SOURCE_DIR})
-add_executable(test_propagate_const test_propagate_const.cpp)
-
-enable_testing()
-add_test(
-  NAME test_propagate_const
-  COMMAND test_propagate_const
-  WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
-

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2017 Jonathan B. Coe
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,3 +3,41 @@
 On 2015-02-25 a proposal was accepted by the Library Working Group as N4388
 and will be put forward for inclusion in Library Fundamentals Technical 
 Specification V2.
+
+
+# Building
+
+The project contains a helper scripts for building that can be found at **<project root>/scripts/build.py**. The project can be build with the helper scipt as follows:
+
+```bash
+cd <project root>
+python script/build.py [--clean] [-o|--output=<build dir>] [-c|--config=<Debug|Release>] [--sanitizers] [-v|--verbose] [-t|--tests]
+```
+
+The script will by default build the project via Visual Studio on Windows. On Linux and Mac it will attempt to build via Ninja if available, then Make and will default to the system defaults for choice of compiler.
+
+## Building Manually Via CMake
+
+It is possible to build the project manually via CMake for a finer grained level of control regarding underlying build systems and compilers. This can be achieved as follows: 
+```bash
+cd <project root>
+mkdir build
+cd build
+
+cmake -G <generator> <configuration options> ../
+cmake --build ../
+ctest
+```
+
+## Installing Via CMake
+
+```bash
+cd <project root>
+mkdir build
+cd build
+
+cmake -G <generator> <configuration options> -DCMAKE_INSTALL_PREFIX=<install dir> ../
+cmake --install ../
+```
+
+

--- a/propagate_const-config.cmake.in
+++ b/propagate_const-config.cmake.in
@@ -1,0 +1,5 @@
+@PACKAGE_INIT@
+
+set_and_check(PROPAGATE_CONST_INCLUDE_DIR "@PACKAGE_INCLUDE_INSTALL_DIR@")
+
+check_required_components(propagate_const)

--- a/scripts/build.py
+++ b/scripts/build.py
@@ -36,6 +36,11 @@ def main():
         help='config (Debug or Release)',
         default='Debug',
         dest='config')
+    parser.add_argument(
+        '--sanitizers',
+        help='Run tests with address and undefined behaviour sanitizer if available',
+        default=False,
+        dest='sanitizers')
 
     if platform.system() == "Windows":
         parser.add_argument(
@@ -55,9 +60,9 @@ def main():
     cmake_invocation = ['cmake', '.', '-B{}'.format(args.out_dir)]
     if args.platform == 'Windows':
         if args.win32:
-            cmake_invocation.extend(['-G', 'Visual Studio 14 2015'])
+            cmake_invocation.extend(['-G', 'Visual Studio 15 2017'])
         else:
-            cmake_invocation.extend(['-G', 'Visual Studio 14 2015 Win64'])
+            cmake_invocation.extend(['-G', 'Visual Studio 15 2017 Win64'])
     else:
         if check_for_executable('ninja'):
             cmake_invocation.extend(['-GNinja'])
@@ -66,6 +71,9 @@ def main():
 
     if args.verbose:
         cmake_invocation.append('-DCMAKE_VERBOSE_MAKEFILE:BOOL=ON')
+
+    if args.sanitizers:
+        cmake_invocation.append('-DENABLE_SANITIZERS:BOOL=ON')
 
     subprocess.check_call(cmake_invocation, cwd=src_dir)
     subprocess.check_call(


### PR DESCRIPTION
This update moves the CMake script for this project over to using modern target based CMake.  This main CMakeList.txt is now includable in other projects either via git submodule, CMake Fetch_Content or sub-projecting methods.  

The project now has an install and packaging phase, which packages up the contents with config and version information in a platform-independent manner (as this is a header-only library).  This is packaged in a relocatable form so that works for Window and Mac where install locations are not fixed. 