### PR TITLE
Add missing CMake include to fix broken build on OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,3 @@ doc/html/*
 doc/polymorphic_value_reference.xml
 makePDF.sh
 talks/.ipynb_checkpoints
-_deps

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ doc/html/*
 doc/polymorphic_value_reference.xml
 makePDF.sh
 talks/.ipynb_checkpoints
+_deps

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ if (${PROPAGATE_CONST_IS_NOT_SUBPROJECT})
             NAME test_propagate_const
             COMMAND test_propagate_const
             WORKING_DIRECTORY ${CMAKE_RUNTIME_OUTPUT_DIRECTORY})
+        include(Catch)
         catch_discover_tests(test_propagate_const)
 
     


### PR DESCRIPTION
Add _deps to .gitignore as it gets created during a build.